### PR TITLE
Fix layout bug: center main section of app

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -110,6 +110,7 @@ main {
   height: 100%;
   padding: var(--space-xs) var(--space-s);
   max-width: var(--width-device-max);
+  margin: auto;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
I was testing the game on a wider screen and realized we forgot to center the main sections of the app:
![Screen Shot 2022-10-28 at 18 29 11](https://user-images.githubusercontent.com/62935115/198689091-0cae3067-e41d-49b4-9304-cb4e316859c9.png)

This PR fixes that by setting the margin of `<main />` to `auto` 😅 