### PR TITLE
Add GitHub actions workflow to run code formatting checks on opened PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: PR validations
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  format:
+    name: format code
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v2
+      - name: install dependencies
+        run: npm ci
+      - name: prettier
+        run: npm run prettier
+      - name: eslint
+        run: npm run lint


### PR DESCRIPTION
Closes https://github.com/ThePokeu/EnChord/issues/9.

This PR adds a workflow to use GitHub actions to run code formatting (prettier and eslint) on opened PRs. This accomplishes something similar to the pre-commit hook we already have, but also covers the scenario where we make changes in GitHub (which doesn't invoke the pre-commit hook).

Now when we open a pull request, code formatting checks are automatically run. If the checks fail (for example, here it fails on the missing `}` we talked about), we are prevented from merging the branch:
![Screenshot 2022-11-05 at 13 57 01](https://user-images.githubusercontent.com/62935115/200121360-9cccff98-2b57-432c-9cf1-1ddf8d937844.png)

Clicking on the "Details" link for the failed check brings us to a page with more info about which step failed and why:
![Screenshot 2022-11-05 at 13 57 35](https://user-images.githubusercontent.com/62935115/200121355-77b6e8b4-f6d5-4206-95dd-c7852f71671a.png)

### How to review this PR:
I checked out this branch from `main` with the broken code, so you could see that the check fails. After https://github.com/ThePokeu/EnChord/pull/46 is merged into `main`, please click on "Update branch" for this PR to bring this branch up to date with the fix. You should then see that the checks pass 🙂

After we merge this PR, this check will be run on all future pull requests, and this should further prevent us from accidentally merging broken code to `main` 😄 