### PR TITLE
Display highest and average scores

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -49,9 +49,12 @@ export class Game {
 
     if (this.#userAnswers.length === this.#numberOfQuestions) {
       this.#storeQuizResults();
+      const scores = this.#quizResults.map((result) => result.score);
       this.#publishGameEndEvent({
         userScore: this.#score,
         totalScore: this.#numberOfQuestions,
+        highestScore: Math.max(...scores),
+        averageScore: this.#getAverageScore(scores),
       });
       return;
     }
@@ -174,5 +177,14 @@ export class Game {
   saveUserAnswer(userInput) {
     this.#userAnswers.push(userInput);
     this.#compareAnswers();
+  }
+
+  #getAverageScore(scores) {
+    // Only calculate average from the last 10 scores
+    const lastScores = scores.slice(Math.max(0, scores.length - 10));
+    const averageScore =
+      lastScores.reduce((prev, curr) => prev + curr, 0) / lastScores.length;
+    // Round to 1 decimal point
+    return Math.round(averageScore * 10) / 10;
   }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -189,6 +189,12 @@ button {
   color: var(--color-primary);
 }
 
+.space-between > * {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-s);
+}
+
 /* Components */
 .button--primary {
   background-color: var(--color-primary);

--- a/src/view.js
+++ b/src/view.js
@@ -385,15 +385,40 @@ export class View {
     this.#appContainer.classList.remove(classNames.flowSpaceLarge);
     this.#appContainer.replaceChildren();
 
+    const scoreDisplay = this.#createElement('div');
+    scoreDisplay.classList.add(classNames.buttonsContainerSingle);
+
     const finalUserScoreDisplay = this.#createElement('h3', 'Score: ');
     const finalUserScore = this.#createElement('span');
     finalUserScore.textContent = `${data.userScore} / ${data.totalScore}`;
     finalUserScoreDisplay.append(finalUserScore);
 
+    const highestUserScoreDisplay = this.#createElement(
+      'h3',
+      'Highest score: '
+    );
+    const highestUserScore = this.#createElement('span');
+    highestUserScore.textContent = `${data.highestScore} / ${data.totalScore}`;
+    highestUserScoreDisplay.append(highestUserScore);
+
+    const averageUserScoreDisplay = this.#createElement(
+      'h3',
+      'Average score: '
+    );
+    const averageUserScore = this.#createElement('span');
+    averageUserScore.textContent = `${data.averageScore} / ${data.totalScore}`;
+    averageUserScoreDisplay.append(averageUserScore);
+
     const playGameAgainButton = this.#createButton('Play again!');
     playGameAgainButton.classList.add(classNames.primaryButton);
 
-    this.#appContainer.append(finalUserScoreDisplay, playGameAgainButton);
+    scoreDisplay.append(
+      finalUserScoreDisplay,
+      highestUserScoreDisplay,
+      averageUserScoreDisplay
+    );
+
+    this.#appContainer.append(scoreDisplay, playGameAgainButton);
 
     playGameAgainButton.addEventListener(
       'click',

--- a/src/view.js
+++ b/src/view.js
@@ -388,7 +388,8 @@ export class View {
     const scoreDisplay = this.#createElement('div');
     scoreDisplay.classList.add(classNames.buttonsContainerSingle);
 
-    const finalUserScoreDisplay = this.#createElement('h3', 'Score: ');
+    const finalUserScoreDisplay = this.#createElement('h3', 'Current score: ');
+    finalUserScoreDisplay.classList.add(classNames.highlight);
     const finalUserScore = this.#createElement('span');
     finalUserScore.textContent = `${data.userScore} / ${data.totalScore}`;
     finalUserScoreDisplay.append(finalUserScore);

--- a/src/view.js
+++ b/src/view.js
@@ -31,6 +31,7 @@ const classNames = {
   header: 'header',
   buttonsContainer: 'buttons-container',
   buttonsContainerSingle: 'buttons-container--single',
+  spaceBetween: 'space-between',
 };
 
 export class View {
@@ -386,29 +387,35 @@ export class View {
     this.#appContainer.replaceChildren();
 
     const scoreDisplay = this.#createElement('div');
-    scoreDisplay.classList.add(classNames.buttonsContainerSingle);
+    scoreDisplay.classList.add(
+      classNames.scoresContainer,
+      classNames.spaceBetween
+    );
 
-    const finalUserScoreDisplay = this.#createElement('h3', 'Current score: ');
+    const finalUserScoreDisplay = this.#createElement('div');
     finalUserScoreDisplay.classList.add(classNames.highlight);
-    const finalUserScore = this.#createElement('span');
-    finalUserScore.textContent = `${data.userScore} / ${data.totalScore}`;
-    finalUserScoreDisplay.append(finalUserScore);
-
-    const highestUserScoreDisplay = this.#createElement(
+    const finalUserScoreLabel = this.#createElement('h3', 'Score: ');
+    const finalUserScore = this.#createElement(
       'h3',
-      'Highest score: '
+      `${data.userScore} / ${data.totalScore}`
     );
-    const highestUserScore = this.#createElement('span');
-    highestUserScore.textContent = `${data.highestScore} / ${data.totalScore}`;
-    highestUserScoreDisplay.append(highestUserScore);
+    finalUserScoreDisplay.append(finalUserScoreLabel, finalUserScore);
 
-    const averageUserScoreDisplay = this.#createElement(
+    const highestUserScoreDisplay = this.#createElement('div');
+    const highestUserScoreLabel = this.#createElement('h3', 'Highest score: ');
+    const highestUserScore = this.#createElement(
       'h3',
-      'Average score: '
+      `${data.highestScore} / ${data.totalScore}`
     );
-    const averageUserScore = this.#createElement('span');
-    averageUserScore.textContent = `${data.averageScore} / ${data.totalScore}`;
-    averageUserScoreDisplay.append(averageUserScore);
+    highestUserScoreDisplay.append(highestUserScoreLabel, highestUserScore);
+
+    const averageUserScoreDisplay = this.#createElement('div');
+    const averageUserScoreLabel = this.#createElement('h3', 'Average score: ');
+    const averageUserScore = this.#createElement(
+      'h3',
+      `${data.averageScore} / ${data.totalScore}`
+    );
+    averageUserScoreDisplay.append(averageUserScoreLabel, averageUserScore);
 
     const playGameAgainButton = this.#createButton('Play again!');
     playGameAgainButton.classList.add(classNames.primaryButton);

--- a/src/view.js
+++ b/src/view.js
@@ -387,10 +387,7 @@ export class View {
     this.#appContainer.replaceChildren();
 
     const scoreDisplay = this.#createElement('div');
-    scoreDisplay.classList.add(
-      classNames.scoresContainer,
-      classNames.spaceBetween
-    );
+    scoreDisplay.classList.add(classNames.spaceBetween);
 
     const finalUserScoreDisplay = this.#createElement('div');
     finalUserScoreDisplay.classList.add(classNames.highlight);


### PR DESCRIPTION
Closes https://github.com/ThePokeu/EnChord/issues/49.

With the changes from https://github.com/ThePokeu/EnChord/pull/50, we can now access scores for past games from `localStorage`. This allows us to display a user's highest and average score from the past 10 games.

<img width="300" alt="Screenshot 2022-12-10 at 16 20 54" src="https://user-images.githubusercontent.com/62935115/214019154-7513c221-05aa-46e6-87c9-657581acfde4.png">

**Important:** this branch should be rebased on `main` before merging, after https://github.com/ThePokeu/EnChord/pull/50 has been merged.